### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ typedef void (^TYDownloadStateBlock)(TYDownloadState state,NSString *filePath, N
 // [TYDownloadSessionManager manager].delegate = self;
 // [TYDownLoadDataManager manager].delegate = self;
 
-#pragma mark - TYDownloadDelegate
+# pragma mark - TYDownloadDelegate
 
 - (void)downloadModel:(TYDownloadModel *)downloadModel didUpdateProgress:(TYDownloadProgress *)progress
 {


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
