### PR TITLE
关于下载文件名称的处理问题

### DIFF
--- a/TYDownloadManagerDemo/TYDownloadManager/TYDownLoadModel.m
+++ b/TYDownloadManagerDemo/TYDownloadManager/TYDownLoadModel.m
@@ -73,7 +73,13 @@
 {
     if (self = [self init]) {
         _downloadURL = URLString;
-        _fileName = filePath.lastPathComponent;
+//         _fileName = filePath.lastPathComponent;
+         if ([_downloadURL.lastPathComponent containsString:@"?"]) {
+            NSArray *array = [_downloadURL.lastPathComponent componentsSeparatedByString:@"?"];
+            _fileName = array.firstObject;
+        }else {
+            _fileName = _downloadURL.lastPathComponent;
+        }
         _downloadDirectory = filePath.stringByDeletingLastPathComponent;
         _filePath = filePath;
     }
@@ -83,7 +89,13 @@
 -(NSString *)fileName
 {
     if (!_fileName) {
-        _fileName = _downloadURL.lastPathComponent;
+//         _fileName = _downloadURL.lastPathComponent;
+         if ([_downloadURL.lastPathComponent containsString:@"?"]) {
+            NSArray *array = [_downloadURL.lastPathComponent componentsSeparatedByString:@"?"];
+            _fileName = array.firstObject;
+        }else {
+            _fileName = _downloadURL.lastPathComponent;
+        }
     }
     return _fileName;
 }

--- a/TYDownloadManagerDemo/TYDownloadManager/TYDownLoadModel.m
+++ b/TYDownloadManagerDemo/TYDownloadManager/TYDownLoadModel.m
@@ -73,13 +73,13 @@
 {
     if (self = [self init]) {
         _downloadURL = URLString;
-//         _fileName = filePath.lastPathComponent;
-         if ([_downloadURL.lastPathComponent containsString:@"?"]) {
-            NSArray *array = [_downloadURL.lastPathComponent componentsSeparatedByString:@"?"];
-            _fileName = array.firstObject;
-        }else {
-            _fileName = _downloadURL.lastPathComponent;
-        }
+        _fileName = filePath.lastPathComponent;
+//          if ([_downloadURL.lastPathComponent containsString:@"?"]) {
+//             NSArray *array = [_downloadURL.lastPathComponent componentsSeparatedByString:@"?"];
+//             _fileName = array.firstObject;
+//         }else {
+//             _fileName = _downloadURL.lastPathComponent;
+//         }
         _downloadDirectory = filePath.stringByDeletingLastPathComponent;
         _filePath = filePath;
     }
@@ -89,13 +89,13 @@
 -(NSString *)fileName
 {
     if (!_fileName) {
-//         _fileName = _downloadURL.lastPathComponent;
-         if ([_downloadURL.lastPathComponent containsString:@"?"]) {
-            NSArray *array = [_downloadURL.lastPathComponent componentsSeparatedByString:@"?"];
-            _fileName = array.firstObject;
-        }else {
-            _fileName = _downloadURL.lastPathComponent;
-        }
+        _fileName = _downloadURL.lastPathComponent;
+//          if ([_downloadURL.lastPathComponent containsString:@"?"]) {
+//             NSArray *array = [_downloadURL.lastPathComponent componentsSeparatedByString:@"?"];
+//             _fileName = array.firstObject;
+//         }else {
+//             _fileName = _downloadURL.lastPathComponent;
+//         }
     }
     return _fileName;
 }


### PR DESCRIPTION
项目中用到下载库，偶然的发现了一个问题，如果文件地址跟的有参数，用？隔开，类似于这种形式：http://xxxx.mp4?token=xxxxx&expiretime=xxxx，用项目中 _fileName = _downloadURL.lastPathComponent;获取文件名的方法，本地有这个文件，但是却无法识别，导致在获取本地文件的时候始终为空，后来经过下面的处理：
 if ([_downloadURL.lastPathComponent containsString:@"?"]) {
            NSArray *array = [_downloadURL.lastPathComponent componentsSeparatedByString:@"?"];
            _fileName = array.firstObject;
        }else {
            _fileName = _downloadURL.lastPathComponent;
        }
可以避免因无法识别文件名成导致的问题
具体地方，参见demo中注释掉的地方，主要在TYDownloadModel文件中